### PR TITLE
Eliminate empty line of paragraph's head.

### DIFF
--- a/redpen-paragraph.el
+++ b/redpen-paragraph.el
@@ -203,6 +203,8 @@ if FLAG is not nil, use second command in `redpen-commands'."
          (default-handler
            (lambda ()
              (unless (use-region-p) (mark-paragraph))
+             (if (string= "\n" (thing-at-point 'line t))
+                 (forward-char))
              (buffer-substring-no-properties (region-beginning) (region-end))))
          (string (save-excursion
                    (funcall (or handler default-handler))))
@@ -219,6 +221,8 @@ if FLAG is not nil, use second command in `redpen-commands'."
             (save-excursion
               (unless (use-region-p) (mark-paragraph))
               (goto-char (region-beginning))
+              (if (string= "\n" (thing-at-point 'line t))
+                  (forward-char))
               (cons (1- (line-number-at-pos))
                     (current-column)))))
     (with-current-buffer

--- a/redpen-paragraph.el
+++ b/redpen-paragraph.el
@@ -203,8 +203,10 @@ if FLAG is not nil, use second command in `redpen-commands'."
          (default-handler
            (lambda ()
              (unless (use-region-p) (mark-paragraph))
-             (if (string= "\n" (thing-at-point 'line t))
-                 (forward-char))
+             (let ((text (thing-at-point 'line)))
+               (set-text-properties 0 (length text) nil text)
+               (if (string= "\n" text)
+                   (forward-char)))
              (buffer-substring-no-properties (region-beginning) (region-end))))
          (string (save-excursion
                    (funcall (or handler default-handler))))
@@ -221,8 +223,10 @@ if FLAG is not nil, use second command in `redpen-commands'."
             (save-excursion
               (unless (use-region-p) (mark-paragraph))
               (goto-char (region-beginning))
-              (if (string= "\n" (thing-at-point 'line t))
-                  (forward-char))
+              (let ((text (thing-at-point 'line)))
+                (set-text-properties 0 (length text) nil text)
+                (if (string= "\n" text)
+                    (forward-char)))
               (cons (1- (line-number-at-pos))
                     (current-column)))))
     (with-current-buffer

--- a/test/redpen-paragraph-test.el
+++ b/test/redpen-paragraph-test.el
@@ -135,10 +135,10 @@
                (shell-quote-argument
                 (json-encode '((errors . [])))))))
           (tests '((1 nil "test1\n" (0 . 0)) (1 t "test1\n" (0 . 0))
-                   (2 nil "\ntest2\n" (1 . 0))
-                   (3 nil "\ntest2\n" (1 . 0)) (3 t "\ntest2\n" (1 . 0))
-                   (4 nil "\ntest3" (3 . 0))
-                   (5 nil "\ntest3" (3 . 0)) (5 t "\ntest3" (3 . 0)))))
+                   (2 nil "test2\n" (2 . 0))
+                   (3 nil "test2\n" (2 . 0)) (3 t "test2\n" (2 . 0))
+                   (4 nil "test3" (4 . 0))
+                   (5 nil "test3" (4 . 0)) (5 t "test3" (4 . 0)))))
       (mapc
        (lambda (test)
          (cl-destructuring-bind (line end? buffer beginning-position) test


### PR DESCRIPTION
'mark-paragraph' contains empty line of paragraph's head by 'backward-paragraph'.
But 'org-backward-paragraph' doesn't.
I changed 'mark-paragraph' result as same as 'org-backward-paragraph' result.
